### PR TITLE
Temp solution to remove Integrity error failure

### DIFF
--- a/sqlalchemy_hana/requirements.py
+++ b/sqlalchemy_hana/requirements.py
@@ -259,3 +259,11 @@ class Requirements(requirements.SuiteRequirements):
     @property
     def enforces_check_constraints(self):
         return exclusions.closed()
+
+    @property
+    def duplicate_key_raises_integrity_error(self):
+        """pyhdb raises the integrity_error, whereas hdbcli raises DBAPIError,
+        currently the test test_integrity_error is known to fail when one
+        connects to HANA with hdbcli"""
+
+        return exclusions.succeeds_if('hana+pyhdb')

--- a/sqlalchemy_hana/requirements.py
+++ b/sqlalchemy_hana/requirements.py
@@ -260,10 +260,3 @@ class Requirements(requirements.SuiteRequirements):
     def enforces_check_constraints(self):
         return exclusions.closed()
 
-    @property
-    def duplicate_key_raises_integrity_error(self):
-        """pyhdb raises the integrity_error, whereas hdbcli raises DBAPIError,
-        currently the test test_integrity_error is known to fail when one
-        connects to HANA with hdbcli"""
-
-        return exclusions.succeeds_if('hana+pyhdb')


### PR DESCRIPTION
If a duplicate key is entered, hdbcli shows a different DBAPI error, whereas the expected error is Integrity_error, pyhdb works correctly and delivers the expected error, hence the test dependent on this requirement should currently only pass with pyhdb