### PR TITLE
Temp solution for the DBAPI error in Exception Test

### DIFF
--- a/sqlalchemy_hana/requirements.py
+++ b/sqlalchemy_hana/requirements.py
@@ -259,3 +259,11 @@ class Requirements(requirements.SuiteRequirements):
     @property
     def enforces_check_constraints(self):
         return exclusions.closed()
+
+    @property
+    def duplicate_key_raises_integrity_error(self):
+        """pyhdb raises the integrity_error, whereas hdbcli raises DBAPIError,
+        currently the test test_integrity_error is known to fail when one
+        connects to HANA with hdbcli"""
+
+        return exclusions.succeeds_if('hana+pyhdb')

--- a/sqlalchemy_hana/requirements.py
+++ b/sqlalchemy_hana/requirements.py
@@ -260,10 +260,3 @@ class Requirements(requirements.SuiteRequirements):
     def enforces_check_constraints(self):
         return exclusions.closed()
 
-    @property
-    def duplicate_key_raises_integrity_error(self):
-        """pyhdb raises the integrity_error, whereas hdbcli raises DBAPIError,
-        currently the test test_integrity_error is known to fail when one
-        connects to HANA with hdbcli"""
-
-        return exclusions.succeeds_if('hana+pyhdb')


### PR DESCRIPTION
Catching the dbapi error and re-throwing the integrity error.