### PR TITLE
HANA supports foreign key options and name.

### DIFF
--- a/sqlalchemy_hana/dialect.py
+++ b/sqlalchemy_hana/dialect.py
@@ -360,8 +360,8 @@ ORDER BY POSITION"""
 
         result = connection.execute(
             sql.text(
-                "SELECT COLUMN_NAME, REFERENCED_SCHEMA_NAME, "
-                "REFERENCED_TABLE_NAME,  REFERENCED_COLUMN_NAME "
+                "SELECT  CONSTRAINT_NAME, COLUMN_NAME, REFERENCED_SCHEMA_NAME, "
+                "REFERENCED_TABLE_NAME,  REFERENCED_COLUMN_NAME, UPDATE_RULE, DELETE_RULE "
                 "FROM REFERENTIAL_CONSTRAINTS "
                 "WHERE SCHEMA_NAME=:schema AND TABLE_NAME=:table "
                 "ORDER BY CONSTRAINT_NAME, POSITION"
@@ -370,18 +370,23 @@ ORDER BY POSITION"""
                 table=self.denormalize_name(table_name)
             )
         )
-
         foreign_keys = []
+
         for row in result:
+
             foreign_key = {
-                "name": None,  # No named foreign key support
-                "constrained_columns": [self.normalize_name(row[0])],
-                "referred_schema": None,
-                "referred_table": self.normalize_name(row[2]),
-                "referred_columns": [self.normalize_name(row[3])],
+                "name": self.normalize_name(row[0]),
+                "constrained_columns": [self.normalize_name(row[1])],
+                "referred_schema": schema,
+                "referred_table": self.normalize_name(row[3]),
+                "referred_columns": [self.normalize_name(row[4])],
+                "options": {"onupdate": row[5],
+                            "ondelete": row[6]}
             }
-            if row[1] != self.denormalize_name(self.default_schema_name):
-                foreign_key["referred_schema"] = self.normalize_name(row[1])
+
+            if row[2] != self.denormalize_name(self.default_schema_name):
+                foreign_key["referred_schema"] = self.normalize_name(row[2])
+
             foreign_keys.append(foreign_key)
 
         return foreign_keys

--- a/sqlalchemy_hana/requirements.py
+++ b/sqlalchemy_hana/requirements.py
@@ -38,8 +38,7 @@ class Requirements(requirements.SuiteRequirements):
 
     @property
     def named_constraints(self):
-        """target database must support names for constraints."""
-        return exclusions.closed()
+        return exclusions.open()
 
     @property
     def unique_constraint_reflection(self):
@@ -51,8 +50,7 @@ class Requirements(requirements.SuiteRequirements):
 
     @property
     def self_referential_foreign_keys(self):
-        """SAP HANA doen't support self-referential foreign keys."""
-        return exclusions.closed()
+        return exclusions.open()
 
     @property
     def empty_inserts(self):
@@ -263,3 +261,7 @@ class Requirements(requirements.SuiteRequirements):
     @property
     def enforces_check_constraints(self):
         return exclusions.closed()
+
+    @property
+    def implicitly_named_constraints(self):
+        return exclusions.open()


### PR DESCRIPTION
HANA gives names to each constraint, hence names are given to constraints implicitly and since foreign key is also a constraint, a name is also generated for it. The default option for foreign keys in HANA is "RESTRICT".