### PR TITLE
Table oid is supported by HANA

### DIFF
--- a/sqlalchemy_hana/dialect.py
+++ b/sqlalchemy_hana/dialect.py
@@ -154,13 +154,10 @@ class HANAExecutionContext(default.DefaultExecutionContext):
 class HANAInspector(reflection.Inspector):
 
     def __init__(self, conn):
-        reflection.Inspector.__init__(self, conn)
+        super(HANAInspector, self).__init__(conn)
 
     def get_table_oid(self, table_name, schema=None):
-        """Return the OID for the given table name."""
-
-        return self.dialect.get_table_oid(self.bind, table_name, schema,
-                                          info_cache=self.info_cache)
+        return self.dialect.get_table_oid(self.bind, table_name, schema, info_cache=self.info_cache)
 
 
 class HANABaseDialect(default.DefaultDialect):
@@ -558,9 +555,7 @@ ORDER BY POSITION"""
             )
         )
 
-        table_oid = None
-        for row in result.fetchall():
-            table_oid = row[0]
+        table_oid = (result.fetchone())[0]
         return table_oid
 
 

--- a/sqlalchemy_hana/dialect.py
+++ b/sqlalchemy_hana/dialect.py
@@ -153,9 +153,6 @@ class HANAExecutionContext(default.DefaultExecutionContext):
 # }
 class HANAInspector(reflection.Inspector):
 
-    def __init__(self, conn):
-        super(HANAInspector, self).__init__(conn)
-
     def get_table_oid(self, table_name, schema=None):
         return self.dialect.get_table_oid(self.bind, table_name, schema, info_cache=self.info_cache)
 

--- a/sqlalchemy_hana/dialect.py
+++ b/sqlalchemy_hana/dialect.py
@@ -13,10 +13,10 @@
 # language governing permissions and limitations under the License.
 
 from sqlalchemy import sql, types, util
-from sqlalchemy.engine import default
+from sqlalchemy.engine import default, reflection
 from sqlalchemy.sql import compiler
 from sqlalchemy.sql.elements import quoted_name
-
+from sqlalchemy import exc
 from sqlalchemy_hana import types as hana_types
 
 
@@ -151,6 +151,17 @@ class HANAExecutionContext(default.DefaultExecutionContext):
 #     'CLOB': hana_types.CLOB,
 #     'NCLOB': hana_types.NCLOB,
 # }
+class HANAInspector(reflection.Inspector):
+
+    def __init__(self, conn):
+        reflection.Inspector.__init__(self, conn)
+
+    def get_table_oid(self, table_name, schema=None):
+        """Return the OID for the given table name."""
+
+        return self.dialect.get_table_oid(self.bind, table_name, schema,
+                                          info_cache=self.info_cache)
+
 
 class HANABaseDialect(default.DefaultDialect):
     name = "hana"
@@ -161,6 +172,7 @@ class HANABaseDialect(default.DefaultDialect):
     ddl_compiler = HANADDLCompiler
     preparer = HANAIdentifierPreparer
     execution_ctx_cls = HANAExecutionContext
+    inspector = HANAInspector
 
     encoding = "cesu-8"
     convert_unicode = True
@@ -532,6 +544,25 @@ ORDER BY POSITION"""
             connection.setautocommit(True)
         else:
             connection.setautocommit(False)
+
+    def get_table_oid(self, connection, table_name, schema=None, **kw):
+        schema = schema or self.default_schema_name
+
+        result = connection.execute(
+            sql.text(
+                "SELECT TABLE_OID FROM TABLES "
+                "WHERE SCHEMA_NAME=:schema AND TABLE_NAME=:table"
+            ).bindparams(
+                schema=self.denormalize_name(schema),
+                table=self.denormalize_name(table_name)
+            )
+        )
+
+        table_oid = None
+        for row in result.fetchall():
+            table_oid = row[0]
+        return table_oid
+
 
 class HANAPyHDBDialect(HANABaseDialect):
 

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -116,3 +116,12 @@ class ComponentReflectionTest(_ComponentReflectionTest):
         for refl in reflected:
             refl.pop('duplicates_index', None)
         eq_(reflected, [{'column_names': ['name'], 'name': 'user_tmp_uq'}])
+
+    @testing.provide_metadata
+    def _test_get_table_oid(self, table_name, schema=None):
+        meta = self.metadata
+        users, addresses, dingalings = self.tables.users, \
+            self.tables.email_addresses, self.tables.dingalings
+        insp = inspect(meta.bind)
+        oid = insp.get_table_oid(table_name, schema)
+        self.assert_(isinstance(oid, int))

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -120,8 +120,6 @@ class ComponentReflectionTest(_ComponentReflectionTest):
     @testing.provide_metadata
     def _test_get_table_oid(self, table_name, schema=None):
         meta = self.metadata
-        users, addresses, dingalings = self.tables.users, \
-            self.tables.email_addresses, self.tables.dingalings
         insp = inspect(meta.bind)
         oid = insp.get_table_oid(table_name, schema)
         self.assert_(isinstance(oid, int))


### PR DESCRIPTION
Extended the inspector to include get_table_oid, made the test_get_table_oid available for HANA