### PR TITLE
HANA supports microseconds in timestamp

### DIFF
--- a/sqlalchemy_hana/requirements.py
+++ b/sqlalchemy_hana/requirements.py
@@ -80,8 +80,7 @@ class Requirements(requirements.SuiteRequirements):
 
     @property
     def datetime_microseconds(self):
-        """No support for microseconds in datetime"""
-        return exclusions.closed()
+        return exclusions.skip_if('hana+pyhdb')
 
     @property
     def datetime_historic(self):


### PR DESCRIPTION
Hana supports microseconds in the datatype timestamp, but currently microseconds is not being extracted in pyhdb