### PR TITLE
HANA supports percent sign and spaces in table and column names

### DIFF
--- a/sqlalchemy_hana/requirements.py
+++ b/sqlalchemy_hana/requirements.py
@@ -101,7 +101,7 @@ class Requirements(requirements.SuiteRequirements):
 
     @property
     def percent_schema_names(self):
-        return exclusions.closed()
+        return exclusions.open()
 
     @property
     def savepoints(self):


### PR DESCRIPTION
HANA supports percent sign and spaces in table and column names in case they are given as delimited identifiers, which means within double quotes.