### PR TITLE
HDB User store implementation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,19 @@ instance. This engine works like all other engines of SQLAlchemy.
     from sqlalchemy import create_engine
     engine = create_engine('hana://username:password@example.de:30015')
 
+Alternatively, you can use HDB User Store to avoid entering connection-related information manually each time you want to establish a connection to an SAP HANA database:
+
+.. code-block:: python
+
+    from sqlalchemy import create_engine
+    engine = create_engine('hana://userkey=my_user_store_key')
+
+You can create your user key in the user store using the following command:
+
+.. code-block:: 
+
+	hdbuserstore SET <KEY> <host:port> <USERNAME> <PASSWORD>
+
 By default the ``hana://`` schema will use hdbcli (from the SAP HANA Client) as underlying database driver.
 To use PyHDB as driver use ``hana+pyhdb://`` as schema in your DBURI.
 

--- a/sqlalchemy_hana/dialect.py
+++ b/sqlalchemy_hana/dialect.py
@@ -545,7 +545,7 @@ class HANABaseDialect(default.DefaultDialect):
                     # Constraint has user-defined name
                     constraint['name'] = self.normalize_name(constraint_name)
                     constraint['duplicates_index'] = self.normalize_name(constraint_name)
-                    constraints.append(constraint)
+                constraints.append(constraint)
             constraint['column_names'].append(self.normalize_name(column_name))
 
         return constraints

--- a/sqlalchemy_hana/dialect.py
+++ b/sqlalchemy_hana/dialect.py
@@ -240,7 +240,10 @@ class HANABaseDialect(default.DefaultDialect):
 
     def _get_default_schema_name(self, connection):
         # return self.normalize_name(connection.engine.url.username.upper())
-        return self.normalize_name(connection.execute("SELECT CURRENT_USER FROM DUMMY").fetchone()[0])
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT CURRENT_USER FROM DUMMY")
+            result = cursor.fetchone()
+        return result[0]
 
     def _check_unicode_returns(self, connection):
         return True

--- a/sqlalchemy_hana/dialect.py
+++ b/sqlalchemy_hana/dialect.py
@@ -239,7 +239,7 @@ class HANABaseDialect(default.DefaultDialect):
         pass
 
     def _get_default_schema_name(self, connection):
-        return self.normalize_name(connection.engine.url.username.upper())
+        # return self.normalize_name(connection.engine.url.username.upper())
         return self.normalize_name(connection.execute("SELECT CURRENT_USER FROM DUMMY").fetchone()[0])
 
     def _check_unicode_returns(self, connection):

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -123,3 +123,15 @@ class ComponentReflectionTest(_ComponentReflectionTest):
         insp = inspect(meta.bind)
         oid = insp.get_table_oid(table_name, schema)
         self.assert_(isinstance(oid, int))
+
+class HANAConnectUrlUserHDBUserStoreTest(fixtures.TestBase):
+
+    @testing.only_on('hana')
+    @testing.only_if('hana+hdbcli')
+    def test_tenant_url_parsing_hdbcli(self):
+        import sqlalchemy.engine.url
+
+        dialect = testing.db.dialect
+
+        _, result_kwargs = dialect.create_connect_args(sqlalchemy.engine.url.make_url("hana://userkey=myhxe"))
+        assert result_kwargs['userkey'] == "myhxe"

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -135,3 +135,18 @@ class HANAConnectUrlUserHDBUserStoreTest(fixtures.TestBase):
 
         _, result_kwargs = dialect.create_connect_args(sqlalchemy.engine.url.make_url("hana://userkey=myhxe"))
         assert result_kwargs['userkey'] == "myhxe"
+
+
+    @testing.only_on('hana')
+    @testing.only_if('hana+pyhdb')
+    def test_tenant_url_parsing_pyhdb(self):
+        import sqlalchemy.engine.url
+
+        dialect = testing.db.dialect
+
+        assert_raises(NotImplementedError, dialect.create_connect_args, sqlalchemy.engine.url.make_url("hana+pyhdb://userkey=myhxe"))
+        
+        # _, result_kwargs = dialect.create_connect_args(sqlalchemy.engine.url.make_url("hana+pyhdb://userkey=myhxe"))
+        # assert result_kwargs['userkey'] == "myhxe"
+        # assert dialect.is_disconnect(Error(-10709, 'Connect failed'), None, None)
+        # assert_raises_message(NotImplementedError, 'no support for HDB user store')

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -14,8 +14,8 @@
 
 # test/test_suite.py
 
-from sqlalchemy import testing
-from sqlalchemy.testing import engines
+from sqlalchemy import testing, create_engine
+from sqlalchemy.testing import engines, assert_raises_message
 from sqlalchemy.testing.suite import *
 from sqlalchemy.testing.exclusions import skip_if
 from sqlalchemy.testing.mock import Mock
@@ -51,6 +51,7 @@ class HANAConnectionIsDisconnectedTest(fixtures.TestBase):
         )
         assert not dialect.is_disconnect(None, mock_connection, None)
 
+
 class HANAConnectUrlHasTenantTest(fixtures.TestBase):
 
     @testing.only_on('hana')
@@ -71,6 +72,7 @@ class HANAConnectUrlHasTenantTest(fixtures.TestBase):
         dialect = testing.db.dialect
 
         assert_raises(NotImplementedError, dialect.create_connect_args, sqlalchemy.engine.url.make_url("hana://USER:PASS@HOST/TNT"))
+
 
 class ComponentReflectionTest(_ComponentReflectionTest):
 
@@ -107,22 +109,132 @@ class ComponentReflectionTest(_ComponentReflectionTest):
                 DDL("drop view user_tmp_v")
             )
 
-    @skip_if('hana')
-    @testing.requires.temp_table_reflection
-    @testing.requires.unique_constraint_reflection
-    def test_get_temp_table_unique_constraints(self):
-        insp = inspect(self.bind)
-        reflected = insp.get_unique_constraints('user_tmp')
-        for refl in reflected:
-            refl.pop('duplicates_index', None)
-        eq_(reflected, [{'column_names': ['name'], 'name': 'user_tmp_uq'}])
-
     @testing.provide_metadata
     def _test_get_table_oid(self, table_name, schema=None):
         meta = self.metadata
         insp = inspect(meta.bind)
         oid = insp.get_table_oid(table_name, schema)
         self.assert_(isinstance(oid, int))
+
+
+class IsolationLevelTest(fixtures.TestBase):
+
+    def _default_isolation_level(self):
+        return 'READ COMMITTED'
+
+    def _non_default_isolation_level(self):
+        return 'SERIALIZABLE'
+
+    @testing.only_on('hana')
+    def test_get_isolation_level(self):
+        eng = engines.testing_engine(options=dict())
+        isolation_level = eng.dialect.get_isolation_level(
+            eng.connect().connection)
+        eq_(
+            isolation_level,
+            self._default_isolation_level()
+        )
+
+    @testing.only_on('hana')
+    @testing.only_if('hana+hdbcli')
+    def test_set_isolation_level(self):
+        eng = engines.testing_engine(options=dict())
+        conn = eng.connect()
+        eq_(
+            eng.dialect.get_isolation_level(conn.connection),
+            self._default_isolation_level()
+        )
+
+        eng.dialect.set_isolation_level(
+            conn.connection, self._non_default_isolation_level()
+        )
+
+        eq_(
+            eng.dialect.get_isolation_level(conn.connection),
+            self._non_default_isolation_level()
+        )
+        conn.close()
+
+    @testing.only_on('hana')
+    @testing.only_if('hana+hdbcli')
+    def test_reset_level(self):
+        eng = engines.testing_engine(options=dict())
+        conn = eng.connect()
+        eq_(
+            eng.dialect.get_isolation_level(conn.connection),
+            self._default_isolation_level()
+        )
+
+        eng.dialect.set_isolation_level(
+            conn.connection, self._non_default_isolation_level()
+        )
+        eq_(
+            eng.dialect.get_isolation_level(conn.connection),
+            self._non_default_isolation_level()
+        )
+
+        eng.dialect.reset_isolation_level(conn.connection)
+        eq_(
+            eng.dialect.get_isolation_level(conn.connection),
+            self._default_isolation_level()
+        )
+        conn.close()
+
+    @testing.only_on('hana')
+    @testing.only_if('hana+hdbcli')
+    def test_set_level_with_setting(self):
+        eng = engines.testing_engine(options=dict(isolation_level=self._non_default_isolation_level()))
+        conn = eng.connect()
+        eq_(
+            eng.dialect.get_isolation_level(conn.connection),
+            self._non_default_isolation_level()
+        )
+
+        eng.dialect.set_isolation_level(conn.connection, self._default_isolation_level())
+        eq_(
+            eng.dialect.get_isolation_level(conn.connection),
+            self._default_isolation_level()
+        )
+        conn.close()
+
+    @testing.only_on('hana')
+    @testing.only_if('hana+hdbcli')
+    def test_invalid_level(self):
+        eng = engines.testing_engine(options=dict(isolation_level='FOO'))
+        assert_raises_message(
+            exc.ArgumentError,
+            "Invalid value '%s' for isolation_level. "
+            "Valid isolation levels for %s are %s" %
+            ("FOO", eng.dialect.name, ", ".join(eng.dialect._isolation_lookup)), eng.connect
+        )
+
+    @testing.only_on('hana')
+    @testing.only_if('hana+hdbcli')
+    def test_with_execution_options(self):
+        eng = create_engine(
+            testing.db.url,
+            execution_options={'isolation_level': self._non_default_isolation_level()}
+            )
+        conn = eng.connect()
+        eq_(
+            eng.dialect.get_isolation_level(conn.connection),
+            self._non_default_isolation_level()
+        )
+        conn.close()
+
+    @testing.only_on('hana')
+    @testing.only_if('hana+hdbcli')
+    def test_with_isolation_level_in_create_engine(self):
+        eng = create_engine(
+            testing.db.url,
+            isolation_level=self._non_default_isolation_level()
+            )
+        conn = eng.connect()
+        eq_(
+            eng.dialect.get_isolation_level(conn.connection),
+            self._non_default_isolation_level()
+        )
+        conn.close()
 
 class HANAConnectUrlUserHDBUserStoreTest(fixtures.TestBase):
 

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -128,7 +128,7 @@ class HANAConnectUrlUserHDBUserStoreTest(fixtures.TestBase):
 
     @testing.only_on('hana')
     @testing.only_if('hana+hdbcli')
-    def test_tenant_url_parsing_hdbcli(self):
+    def test_parsing_userkey_hdbcli(self):
         import sqlalchemy.engine.url
 
         dialect = testing.db.dialect
@@ -139,14 +139,9 @@ class HANAConnectUrlUserHDBUserStoreTest(fixtures.TestBase):
 
     @testing.only_on('hana')
     @testing.only_if('hana+pyhdb')
-    def test_tenant_url_parsing_pyhdb(self):
+    def test_parsing_userkey_pyhdb(self):
         import sqlalchemy.engine.url
 
         dialect = testing.db.dialect
 
         assert_raises(NotImplementedError, dialect.create_connect_args, sqlalchemy.engine.url.make_url("hana+pyhdb://userkey=myhxe"))
-        
-        # _, result_kwargs = dialect.create_connect_args(sqlalchemy.engine.url.make_url("hana+pyhdb://userkey=myhxe"))
-        # assert result_kwargs['userkey'] == "myhxe"
-        # assert dialect.is_disconnect(Error(-10709, 'Connect failed'), None, None)
-        # assert_raises_message(NotImplementedError, 'no support for HDB user store')


### PR DESCRIPTION
Sorry, I think I messed up between my local git and the online one.
So, I decided to recreate the pull request from scratch.

I've implemented the self.normalize_name.

But regarding the current schema vs current user, I have some interrogations.

I know that the CURRENT_SCHEMA doesn't reflect the HANA user default schema. A user in HANA always have it's own default schema (named by the user id), and there is no way to change the user default schema compared to other db like postgresql.

However, during a session a user can switch schema and avoid the schema prefixing using a set schema which is what you get with the CURRENT_SCHEMA

And the doc says:
default_schema_name: Return the default schema name presented by the dialect for the current engine’s database user. E.g. this is typically public for PostgreSQL and dbo for SQL Server.

So in our case it should be CURRENT_USER.