### PR TITLE
Update dialect.py for get_table_names() issue with is_user_defined_type

### DIFF
--- a/sqlalchemy_hana/dialect.py
+++ b/sqlalchemy_hana/dialect.py
@@ -309,7 +309,7 @@ class HANABaseDialect(default.DefaultDialect):
 
         result = connection.execute(
             sql.text(
-                "SELECT TABLE_NAME, IS_TEMPORARY FROM TABLES WHERE SCHEMA_NAME=:schema",
+                "SELECT TABLE_NAME, IS_TEMPORARY FROM TABLES WHERE SCHEMA_NAME=:schema AND IS_USER_DEFINED_TYPE='FALSE'",
             ).bindparams(
                 schema=self.denormalize_name(schema),
             )


### PR DESCRIPTION
I found a bug in get_tables_names() implementation while executing the sql Alchemy tests.
For some reason my HXE installation created a user defined type in the system catalog of my HANA
instance (SYS_AFL_GENERATOR_PARAMETERS).
After investigation I succeeded to understand what a user_defined_type is used for in HANA.
This is used to define the strutcture of resultsets returned by functions/stored procedures. It has 
nothing to do with real tables or views. It is created and dropped by a specific syntaxes 
'create type as table" and  'drop type...".
These entries should not be returned to the user when retrieving the list of tables names available in the
current schema.