### PR TITLE
Testing: Close decimal retains_significant_digits

### DIFF
--- a/sqlalchemy_hana/requirements.py
+++ b/sqlalchemy_hana/requirements.py
@@ -66,7 +66,7 @@ class Requirements(requirements.SuiteRequirements):
 
     @property
     def precision_numerics_retains_significant_digits(self):
-        return exclusions.open()
+        return exclusions.closed()
 
     @property
     def datetime_literals(self):


### PR DESCRIPTION
SQLAlchemy expects that the database retains all decimal places
based on the column's scale definition even when they are zero.
Python drivers for SAP HANA fully supports the decimal datatype
but doesn't follow this behaviour.