### PR TITLE
Issue Fix: #50 - Unable to connect to HANA via SSL

### DIFF
--- a/sqlalchemy_hana/dialect.py
+++ b/sqlalchemy_hana/dialect.py
@@ -654,6 +654,7 @@ class HANAHDBCLIDialect(HANABaseDialect):
             kwargs["userkey"] = userkey
         else:
             kwargs = url.translate_connect_args(host="address", username="user", database="databaseName")
+            kwargs.update(url.query)
             port = 30015
             if kwargs.get("databaseName"):
                 port = 30013

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -301,3 +301,22 @@ class HANAConnectUrlUserHDBUserStoreTest(fixtures.TestBase):
         dialect = testing.db.dialect
 
         assert_raises(NotImplementedError, dialect.create_connect_args, sqlalchemy.engine.url.make_url("hana+pyhdb://userkey=myhxe"))
+
+
+class HANAConnectUrlParsing(fixtures.TestBase):
+
+    @testing.only_on('hana')
+    @testing.only_if('hana+hdbcli')
+    def test_pass_uri_query_as_kwargs(self):
+        """Verify sqlalchemy-hana passes all uri query parameters to hdbcli"""
+        import sqlalchemy.engine.url
+
+        dialect = testing.db.dialect
+
+        _, kwargs = dialect.create_connect_args(
+            sqlalchemy.engine.url.make_url(
+                "hana+hdbcli://user:password@example.com/my-database?encrypt=true&compress=true"
+            )
+        )
+        assert kwargs["encrypt"] == "true"
+        assert kwargs["compress"] == "true"


### PR DESCRIPTION
https://github.com/SAP/sqlalchemy-hana/issues/50

Query parameters specified in the database URL were not being added to connect_args
This is why the OP was losing ?encrypt=true

I'e added a fix to include them.

I've tested this against a live hana instance on SAP Cloud Platform but have not tested via the test suite.

S.