### PR TITLE
Changing default connector to open-source pyhdb

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     ],
      entry_points = {  
          'sqlalchemy.dialects': 
-         ['hana = sqlalchemy_hana.dialect:HANAHDBCLIDialect',         
+         ['hana = sqlalchemy_hana.dialect:HANAPyHDBDialect',         
           'hana.hdbcli = sqlalchemy_hana.dialect:HANAHDBCLIDialect',         
           'hana.pyhdb = sqlalchemy_hana.dialect:HANAPyHDBDialect']   
      },


### PR DESCRIPTION
 On branch master

 Changes to be committed:
	modified:   setup.py

Modified setup.py: default connector was cahnged from hdbcli to pyhdb
because pyhdb library is more stable and easier to install.