### PR TITLE
Support 'SMALLDECIMAL' type of HANA

### DIFF
--- a/sqlalchemy_hana/dialect.py
+++ b/sqlalchemy_hana/dialect.py
@@ -105,6 +105,9 @@ class HANATypeCompiler(compiler.GenericTypeCompiler):
     def visit_DOUBLE(self, type_):
         return "DOUBLE"
 
+    def visit_SMALLDECIMAL(self, type_):
+        return "SMALLDECIMAL"
+
     def visit_unicode(self, type_, **kwargs):
         return self.visit_NVARCHAR(type_, **kwargs)
 

--- a/sqlalchemy_hana/types.py
+++ b/sqlalchemy_hana/types.py
@@ -25,6 +25,10 @@ class DOUBLE(sqltypes.Float):
     __visit_name__ = "DOUBLE"
 
 
+class SMALLDECIMAL(sqltypes.DECIMAL):
+    __visit_name__ = "SMALLDECIMAL"
+
+
 class BOOLEAN(sqltypes.Boolean):
 
     def get_dbapi_type(self, dbapi):


### PR DESCRIPTION
With this change, the user can use the 'SMALLDECIMAL' type of HANA. 