### PR TITLE
Remove copyright comments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,3 @@
-# Copyright 2015 SAP SE.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http: //www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-# either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
-
 import os
 from setuptools import setup, find_packages
 

--- a/sqlalchemy_hana/dialect.py
+++ b/sqlalchemy_hana/dialect.py
@@ -1,17 +1,3 @@
-# Copyright 2015 SAP SE.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http: //www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-# either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
-
 from functools import wraps
 
 from sqlalchemy import sql, types, util

--- a/sqlalchemy_hana/requirements.py
+++ b/sqlalchemy_hana/requirements.py
@@ -1,17 +1,3 @@
-# Copyright 2015 SAP SE.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http: //www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-# either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
-
 import sys
 
 import sqlalchemy

--- a/sqlalchemy_hana/types.py
+++ b/sqlalchemy_hana/types.py
@@ -1,17 +1,3 @@
-# Copyright 2015 SAP SE.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http: //www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-# either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
-
 from sqlalchemy import types as sqltypes
 from sqlalchemy.util import compat
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,17 +1,3 @@
-# Copyright 2021 SAP SE.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http: //www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-# either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
-
 import logging
 
 from sqlalchemy import event, Column, Sequence

--- a/test/test_hana_connect_url.py
+++ b/test/test_hana_connect_url.py
@@ -1,17 +1,3 @@
-# Copyright 2021 SAP SE.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http: //www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-# either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
-
 import sqlalchemy.testing
 from sqlalchemy.engine.url import make_url
 

--- a/test/test_hana_connection.py
+++ b/test/test_hana_connection.py
@@ -1,17 +1,3 @@
-# Copyright 2021 SAP SE.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http: //www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-# either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
-
 import sqlalchemy.testing
 from sqlalchemy.testing.mock import Mock
 

--- a/test/test_hana_sql.py
+++ b/test/test_hana_sql.py
@@ -1,17 +1,3 @@
-# Copyright 2021 SAP SE.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http: //www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-# either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
-
 import sqlalchemy.testing
 from sqlalchemy.sql.expression import table, column
 

--- a/test/test_isolation_level.py
+++ b/test/test_isolation_level.py
@@ -1,17 +1,3 @@
-# Copyright 2021 SAP SE.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http: //www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-# either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
-
 import sqlalchemy
 import sqlalchemy.testing
 from sqlalchemy.testing import eq_

--- a/test/test_sqlalchemy_dialect_suite.py
+++ b/test/test_sqlalchemy_dialect_suite.py
@@ -1,17 +1,3 @@
-# Copyright 2021 SAP SE.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http: //www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-# either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
-
 import sqlalchemy
 
 # Import dialect test suite provided by SQLAlchemy into SQLAlchemy-HANA test collection.


### PR DESCRIPTION
We use 'reuse' which allows us to drop all copyright comments.