### PR TITLE
Fix deprecated dbapi method

### DIFF
--- a/sqlalchemy_hana/dialect.py
+++ b/sqlalchemy_hana/dialect.py
@@ -132,7 +132,7 @@ RESERVED_WORDS = {
     "with",
 }
 
-if sqlalchemy.__version__ < "2.0":
+if sqlalchemy.__version__ < "2":  # pragma: no cover
     # sqlalchemy 1.4 does not like annotations and caching
     def cache(func: Callable[PARAM, RET]) -> Callable[PARAM, RET]:
         return func
@@ -1003,7 +1003,7 @@ class HANAHDBCLIDialect(HANABaseDialect):
         hdbcli.dbapi.paramstyle = cls.default_paramstyle  # type:ignore[assignment]
         return hdbcli.dbapi
 
-    if sqlalchemy.__version__ < "2":
+    if sqlalchemy.__version__ < "2":  # pragma: no cover
         dbapi = import_dbapi  # type:ignore[assignment]
 
     def create_connect_args(self, url: URL) -> ConnectArgsType:

--- a/sqlalchemy_hana/dialect.py
+++ b/sqlalchemy_hana/dialect.py
@@ -999,11 +999,12 @@ class HANAHDBCLIDialect(HANABaseDialect):
     supports_statement_cache = False
 
     @classmethod
-    def dbapi(  # type:ignore[override] # pylint:disable=method-hidden
-        cls,
-    ) -> ModuleType:
+    def import_dbapi(cls) -> ModuleType:
         hdbcli.dbapi.paramstyle = cls.default_paramstyle  # type:ignore[assignment]
         return hdbcli.dbapi
+
+    if sqlalchemy.__version__ < "2":
+        dbapi = import_dbapi  # type:ignore[assignment]
 
     def create_connect_args(self, url: URL) -> ConnectArgsType:
         if url.host and url.host.lower().startswith("userkey="):


### PR DESCRIPTION
In SQLAlchemy 2.0, the dbapi classmethod was renamed to import_dbapi. So for SQLAlchemy 2.0 we use import_dbapi while for SQLAlchemy 1.4 we still need to preserve the dbapi method