### PR TITLE
Remove base dialect

### DIFF
--- a/sqlalchemy_hana/types.py
+++ b/sqlalchemy_hana/types.py
@@ -10,7 +10,7 @@ from sqlalchemy import types as sqltypes
 from sqlalchemy.engine import Dialect
 
 if TYPE_CHECKING:
-    from sqlalchemy_hana.dialect import HANABaseDialect
+    from sqlalchemy_hana.dialect import HANAHDBCLIDialect
 
 
 class TINYINT(sqltypes.Integer):
@@ -77,7 +77,7 @@ class _LOBMixin:
     def result_processor(
         self, dialect: Dialect, coltype: object
     ) -> Callable[[Any], Any] | None:
-        dialect = cast("HANABaseDialect", dialect)
+        dialect = cast("HANAHDBCLIDialect", dialect)
         if not dialect.auto_convert_lobs:
             # Disable processor and return raw DBAPI LOB type
             return None

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -12,7 +12,6 @@ from sqlalchemy.dialects import registry
 logging.getLogger("sqlalchemy.engine").setLevel(logging.DEBUG)
 
 registry.register("hana", "sqlalchemy_hana.dialect", "HANAHDBCLIDialect")
-registry.register("hana.hdbcli", "sqlalchemy_hana.dialect", "HANAHDBCLIDialect")
 pytest.register_assert_rewrite("sqlalchemy.testing.assertions")
 
 


### PR DESCRIPTION
Currently, it does seem likly that we will support another driver than hdbcli. Also, by removing the base dialect class, code complexity is reduced.

If this is ever needed again, we can again add the split