### PR TITLE
Remove setting of paramstyle

### DIFF
--- a/sqlalchemy_hana/dialect.py
+++ b/sqlalchemy_hana/dialect.py
@@ -1045,7 +1045,6 @@ class HANAHDBCLIDialect(HANABaseDialect):
 
     @classmethod
     def import_dbapi(cls) -> ModuleType:
-        hdbcli.dbapi.paramstyle = cls.default_paramstyle  # type:ignore[assignment]
         return hdbcli.dbapi
 
     if sqlalchemy.__version__ < "2":  # pragma: no cover


### PR DESCRIPTION
Overwriting paramstyle in hdbcli has no effect.
This value just explains, which styles are supported but does not effect the driver