### PR TITLE
refactor: Added normalize_column_name parameter to HANABaseDialect so…

### DIFF
--- a/sqlalchemy_hana/dialect.py
+++ b/sqlalchemy_hana/dialect.py
@@ -210,7 +210,6 @@ class HANABaseDialect(default.DefaultDialect):
     supports_default_values = False
     supports_sane_multi_rowcount = False
     isolation_level = None
-    normalize_column_name = True
 
     def __init__(self, isolation_level=None, auto_convert_lobs=True, normalize_column_name=True, **kwargs):
         super(HANABaseDialect, self).__init__(**kwargs)

--- a/test/test_dialect.py
+++ b/test/test_dialect.py
@@ -1,0 +1,71 @@
+"""SAP HANA Dialect testing."""
+
+from __future__ import annotations
+
+from unittest import TestCase
+from unittest.mock import Mock, MagicMock
+
+import sqlalchemy
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Connection, ResultProxy
+from sqlalchemy.testing.fixtures import TestBase
+from sqlalchemy_hana.dialect import HANABaseDialect
+
+DEFAULT_ISOLATION_LEVEL = "READ COMMITTED"
+NON_DEFAULT_ISOLATION_LEVEL = "SERIALIZABLE"
+
+
+class DialectTest(TestCase):
+    def test_get_columns(self) -> None:
+        # COLUMN_NAME, DATA_TYPE_NAME, DEFAULT_VALUE, IS_NULLABLE, LENGTH, SCALE, COMMENTS
+        rows = [
+            ["ID", "BIGINT", None, "FALSE", None, None, None],
+            ["NAME", "NVARCHAR", None, "FALSE", 255, None, None],
+            ["FIRST_NAME", "NVARCHAR", None, "FALSE", 255, None, None],
+            ["GENDER", "NVARCHAR", "M", "FALSE", 1, None, None],
+            ["BIRTHDATE", "DATE", None, "TRUE", None, None, None],
+        ]
+        connection = MagicMock(spec=Connection)
+        result = MagicMock(spec=ResultProxy)
+        result.fetchall.return_value = rows
+        connection.execute.side_effect = lambda sql: result
+        engine = create_engine("hana://user:pass@localhost:3005/HR")
+
+        assert isinstance(engine.dialect, HANABaseDialect)
+
+        actual = engine.dialect.get_columns(connection=connection, table_name="EMPLOYEES", schema="HR")
+
+        assert actual is not None
+        assert len(actual) == 5
+        assert {'comment': None, 'default': None, 'name': 'id', 'nullable': False, 'type': sqlalchemy.sql.sqltypes.BIGINT} in actual
+        assert {'comment': None, 'default': None, 'name': 'name', 'nullable': False, 'type': sqlalchemy.sql.sqltypes.NVARCHAR} in actual
+        assert {'comment': None, 'default': None, 'name': 'first_name', 'nullable': False, 'type': sqlalchemy.sql.sqltypes.NVARCHAR} in actual
+        assert {'comment': None, 'default': 'M', 'name': 'gender', 'nullable': False, 'type': sqlalchemy.sql.sqltypes.NVARCHAR} in actual
+        assert {'comment': None, 'default': None, 'name': 'birthdate', 'nullable': True, 'type': sqlalchemy.sql.sqltypes.DATE} in actual
+
+    def test_get_columns_when_normalize_column_name_disabled(self) -> None:
+        # COLUMN_NAME, DATA_TYPE_NAME, DEFAULT_VALUE, IS_NULLABLE, LENGTH, SCALE, COMMENTS
+        rows = [
+            ["ID", "BIGINT", None, "FALSE", None, None, None],
+            ["NAME", "NVARCHAR", None, "FALSE", 255, None, None],
+            ["FIRST_NAME", "NVARCHAR", None, "FALSE", 255, None, None],
+            ["GENDER", "NVARCHAR", "M", "FALSE", 1, None, None],
+            ["BIRTHDATE", "DATE", None, "TRUE", None, None, None],
+        ]
+        connection = MagicMock(spec=Connection)
+        result = MagicMock(spec=ResultProxy)
+        result.fetchall.return_value = rows
+        connection.execute.side_effect = lambda sql: result
+        engine = create_engine("hana://user:pass@localhost:3005/HR", normalize_column_name=False)
+
+        assert isinstance(engine.dialect, HANABaseDialect)
+
+        actual = engine.dialect.get_columns(connection=connection, table_name="EMPLOYEES", schema="HR")
+
+        assert actual is not None
+        assert len(actual) == 5
+        assert {'comment': None, 'default': None, 'name': 'ID', 'nullable': False, 'type': sqlalchemy.sql.sqltypes.BIGINT} in actual
+        assert {'comment': None, 'default': None, 'name': 'NAME', 'nullable': False, 'type': sqlalchemy.sql.sqltypes.NVARCHAR} in actual
+        assert {'comment': None, 'default': None, 'name': 'FIRST_NAME', 'nullable': False, 'type': sqlalchemy.sql.sqltypes.NVARCHAR} in actual
+        assert {'comment': None, 'default': 'M', 'name': 'GENDER', 'nullable': False, 'type': sqlalchemy.sql.sqltypes.NVARCHAR} in actual
+        assert {'comment': None, 'default': None, 'name': 'BIRTHDATE', 'nullable': True, 'type': sqlalchemy.sql.sqltypes.DATE} in actual


### PR DESCRIPTION
Added a parameter to the HANABaseDialect so that we can configure if we want to normalize column names or not.

At our enterprise, HANA seems to be case sensitive and when we dynamically generate SQL statments based on the columns names returned from the dialect, those do not correspond with the case in our database and thus HANA gives an error saying it doesn't know the column because it's in lower case and in in our case it should be in upper case.

This pull request was based on tag v0.5.0 as we are using Airflow which uses an older version of sqlalchemy which only works with sqlalchemy-hana 0.5.0.  So it would be cool if we could get an additional 0.6.0 version.  I'm also willing to merge this is the current branch so that newer versions of sqlalchemy-hana also benefit from this modification.

So I would need a branch based on 0.5.0 to be able to apply this fix, you can do this in git: `git checkout tags/v0.5.0 -b v0.6.0`

At the moment we have to monkey-patch the get_columns method of the HANABaseDialect in python to bypass this behaviou in sqlalchemy-hana to make it work, so it would be cool if this could become a configurable option.  I also added 2 tests which tests the result of the get_columns method with the default behaviour and when normalize_column_name option is disabled.