### PR TITLE
refactor: Added normalize_column_name parameter to HANAHDBCLIDialect …

### DIFF
--- a/sqlalchemy_hana/dialect.py
+++ b/sqlalchemy_hana/dialect.py
@@ -515,11 +515,13 @@ class HANAHDBCLIDialect(default.DefaultDialect):
         self,
         isolation_level: str | None = None,
         use_native_boolean: bool = True,
+        normalize_column_name=True,
         **kw: Any,
     ) -> None:
         super().__init__(**kw)
         self.isolation_level = isolation_level
         self.supports_native_boolean = use_native_boolean
+        self.normalize_column_name = normalize_column_name
 
     @classmethod
     def import_dbapi(cls) -> ModuleType:
@@ -846,7 +848,7 @@ class HANAHDBCLIDialect(default.DefaultDialect):
         columns: list[ReflectedColumn] = []
         for row in result.fetchall():
             column = {
-                "name": self.normalize_name(row[0]),
+                "name": self.normalize_name(row[0]) if self.normalize_column_name else row[0],
                 "default": row[2],
                 "nullable": row[3] == "TRUE",
                 "comment": row[6],

--- a/test/test_dialect.py
+++ b/test/test_dialect.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
-from unittest.mock import Mock
+from unittest.mock import Mock, MagicMock
 
 import pytest
 from hdbcli.dbapi import Error
 from sqlalchemy import create_engine
+from sqlalchemy.engine import Connection, ResultProxy
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.exc import ArgumentError
+from sqlalchemy.sql.sqltypes import BIGINT, NVARCHAR, DATE
 from sqlalchemy.testing import assert_raises_message, config, eq_
 from sqlalchemy.testing.engines import testing_engine
 from sqlalchemy.testing.fixtures import TestBase
+from sqlalchemy_hana.dialect import HANAHDBCLIDialect
 
 DEFAULT_ISOLATION_LEVEL = "READ COMMITTED"
 NON_DEFAULT_ISOLATION_LEVEL = "SERIALIZABLE"
@@ -176,3 +179,58 @@ class DialectTest(TestBase):
             NON_DEFAULT_ISOLATION_LEVEL,
         )
         conn.close()
+
+    def test_get_columns(self) -> None:
+        # COLUMN_NAME, DATA_TYPE_NAME, DEFAULT_VALUE, IS_NULLABLE, LENGTH, SCALE, COMMENTS
+        rows = [
+            ["ID", "BIGINT", None, "FALSE", None, None, None],
+            ["NAME", "NVARCHAR", None, "FALSE", 255, None, None],
+            ["FIRST_NAME", "NVARCHAR", None, "FALSE", 255, None, None],
+            ["GENDER", "NVARCHAR", "M", "FALSE", 1, None, None],
+            ["BIRTHDATE", "DATE", None, "TRUE", None, None, None],
+        ]
+        connection = MagicMock(spec=Connection)
+        result = MagicMock(spec=ResultProxy)
+        result.fetchall.return_value = rows
+        connection.execute.side_effect = lambda sql: result
+        engine = create_engine("hana://user:pass@localhost:3005/HR")
+
+        assert isinstance(engine.dialect, HANAHDBCLIDialect)
+
+        actual = engine.dialect.get_columns(connection=connection, table_name="EMPLOYEES", schema="HR")
+
+        assert actual is not None
+        assert len(actual) == 5
+        assert {'comment': None, 'default': None, 'name': 'id', 'nullable': False, 'type': BIGINT} in actual
+        assert {'comment': None, 'default': None, 'name': 'name', 'nullable': False, 'type': NVARCHAR} in actual
+        assert {'comment': None, 'default': None, 'name': 'first_name', 'nullable': False, 'type': NVARCHAR} in actual
+        assert {'comment': None, 'default': 'M', 'name': 'gender', 'nullable': False, 'type': NVARCHAR} in actual
+        assert {'comment': None, 'default': None, 'name': 'birthdate', 'nullable': True, 'type': DATE} in actual
+
+    def test_get_columns_when_normalize_column_name_disabled(self) -> None:
+        # COLUMN_NAME, DATA_TYPE_NAME, DEFAULT_VALUE, IS_NULLABLE, LENGTH, SCALE, COMMENTS
+        rows = [
+            ["ID", "BIGINT", None, "FALSE", None, None, None],
+            ["NAME", "NVARCHAR", None, "FALSE", 255, None, None],
+            ["FIRST_NAME", "NVARCHAR", None, "FALSE", 255, None, None],
+            ["GENDER", "NVARCHAR", "M", "FALSE", 1, None, None],
+            ["BIRTHDATE", "DATE", None, "TRUE", None, None, None],
+        ]
+        connection = MagicMock(spec=Connection)
+        result = MagicMock(spec=ResultProxy)
+        result.fetchall.return_value = rows
+        connection.execute.side_effect = lambda sql: result
+        engine = create_engine("hana://user:pass@localhost:3005/HR", normalize_column_name=False)
+
+        assert isinstance(engine.dialect, HANAHDBCLIDialect)
+
+        actual = engine.dialect.get_columns(connection=connection, table_name="EMPLOYEES", schema="HR")
+
+        assert actual is not None
+        assert len(actual) == 5
+        assert {'comment': None, 'default': None, 'name': 'ID', 'nullable': False, 'type': BIGINT} in actual
+        assert {'comment': None, 'default': None, 'name': 'NAME', 'nullable': False, 'type': NVARCHAR} in actual
+        assert {'comment': None, 'default': None, 'name': 'FIRST_NAME', 'nullable': False, 'type': NVARCHAR} in actual
+        assert {'comment': None, 'default': 'M', 'name': 'GENDER', 'nullable': False, 'type': NVARCHAR} in actual
+        assert {'comment': None, 'default': None, 'name': 'BIRTHDATE', 'nullable': True, 'type': DATE} in actual
+


### PR DESCRIPTION
Same as [other other pull](https://github.com/SAP/sqlalchemy-hana/pull/205) request but then applied on latest version in main.  Added a parameter to the HANAHDBCLIDialect so that we can configure if we want to normalize column names or not.

At our enterprise, HANA seems to be case sensitive and when we dynamically generate SQL statments based on the columns names returned from the dialect, those do not correspond with the case in our database and thus HANA gives an error saying it doesn't know the column because it's in lower case and in in our case it should be in upper case.

At the moment we have to monkey-patch the get_columns method of the HANAHDBCLIDialect in python to bypass this behaviou in sqlalchemy-hana to make it work, so it would be cool if this could become a configurable option. I also added 2 tests which tests the result of the get_columns method with the default behaviour and when normalize_column_name option is disabled.