### PR TITLE
Fix get_table_oid in HANAInspector to also work with inspectors created from Engine instances

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ disable = [
     "too-many-lines",
     "too-many-branches",
     "too-many-return-statements",
+    "duplicate-code",
 ]
 
 [tool.pylint.basic]

--- a/sqlalchemy_hana/dialect.py
+++ b/sqlalchemy_hana/dialect.py
@@ -462,12 +462,13 @@ class HANAInspector(reflection.Inspector):
     dialect: HANAHDBCLIDialect
 
     def get_table_oid(self, table_name: str, schema: str | None = None) -> int:
-        return self.dialect.get_table_oid(
-            self.bind,  # type:ignore[arg-type]
-            table_name,
-            schema,
-            info_cache=self.info_cache,
-        )
+        with self._operation_context() as conn:
+            return self.dialect.get_table_oid(
+                conn,
+                table_name,
+                schema,
+                info_cache=self.info_cache,
+            )
 
 
 class HANAHDBCLIDialect(default.DefaultDialect):

--- a/test/test_inspector.py
+++ b/test/test_inspector.py
@@ -1,0 +1,47 @@
+"""SAP HANA Inspector tests."""
+
+from __future__ import annotations
+
+from sqlalchemy import Integer, String, create_engine, inspect
+from sqlalchemy.engine import Connection, Engine
+from sqlalchemy.testing import config, eq_, is_true
+from sqlalchemy.testing.fixtures import TablesTest
+from sqlalchemy.testing.schema import Column, Table
+
+from sqlalchemy_hana.dialect import HANAInspector
+
+
+class InspectorTest(TablesTest):
+
+    @classmethod
+    def define_tables(cls, metadata):
+        Table(
+            "tbl",
+            metadata,
+            Column("id", Integer, primary_key=True, autoincrement=True),
+            Column("desc", String(100)),
+        )
+
+    def test_get_table_oid(self, connection):
+        connection_inspector = inspect(connection)
+
+        is_true(isinstance(connection_inspector, HANAInspector))
+        is_true(isinstance(connection_inspector.bind, Connection))
+
+        table_oid1 = connection_inspector.get_table_oid(
+            self.tables.tbl.name, self.tables.tbl.schema
+        )
+        is_true(isinstance(table_oid1, int))
+
+        eng = create_engine(config.db.url)
+        eng_inspector = inspect(eng)
+
+        is_true(isinstance(eng_inspector, HANAInspector))
+        is_true(isinstance(eng_inspector.bind, Engine))
+
+        table_oid2 = eng_inspector.get_table_oid(
+            self.tables.tbl.name, self.tables.tbl.schema
+        )
+        is_true(isinstance(table_oid2, int))
+
+        eq_(table_oid1, table_oid2)


### PR DESCRIPTION
Similar to the issue for the built-in PostgreSQL dialect resp. the corresponding PGInspector class (https://github.com/sqlalchemy/sqlalchemy/issues/6170) the get_table_oid method of the HANAInspector cannot be used when the inspector was created using the Engine instance and not a Connection instance.

This PR fixes this using the same solution from the PGInspector class (see also here for details: https://gerrit.sqlalchemy.org/c/sqlalchemy/sqlalchemy/+/2697).