### PR TITLE
Support SA 2.1 DropView

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
-        sqlalchemy-version: [2.0.*]
+        sqlalchemy-version: [2.0.*, 2.1.0b2]
         async-mode: [non-async]
         include:
         -   python-version: '3.14'

--- a/sqlalchemy_hana/dialect.py
+++ b/sqlalchemy_hana/dialect.py
@@ -75,10 +75,15 @@ if TYPE_CHECKING:
 if sqlalchemy.__version__ < "2.1":
     from sqlalchemy.sql.ddl import _DropView as BaseDropView
 else:
+    # isort moves the comments around leading to issues
+    # isort: off
     # In SQLAlchemy 2.1, the _DropView class was renamed to DropView.
+    # pylint:disable-next=no-name-in-module
     from sqlalchemy.sql.ddl import (  # type: ignore[attr-defined,no-redef]
         DropView as BaseDropView,
     )
+
+    # isort: on
 
 with contextlib.suppress(ImportError):
     # pylint: disable=unused-import

--- a/sqlalchemy_hana/dialect.py
+++ b/sqlalchemy_hana/dialect.py
@@ -11,6 +11,7 @@ from types import ModuleType
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 import hdbcli.dbapi
+import sqlalchemy
 from sqlalchemy import (
     Computed,
     Identity,
@@ -41,7 +42,6 @@ from typing_extensions import override
 
 from sqlalchemy_hana import types as hana_types
 from sqlalchemy_hana.elements import CreateView, DropView, Upsert
-import sqlalchemy
 
 if TYPE_CHECKING:
     from typing import ParamSpec, TypeVar
@@ -76,7 +76,9 @@ if sqlalchemy.__version__ < "2.1":
     from sqlalchemy.sql.ddl import _DropView as BaseDropView
 else:
     # In SQLAlchemy 2.1, the _DropView class was renamed to DropView.
-    from sqlalchemy.sql.ddl import DropView as BaseDropView
+    from sqlalchemy.sql.ddl import (  # type: ignore[attr-defined,no-redef]
+        DropView as BaseDropView,
+    )
 
 with contextlib.suppress(ImportError):
     # pylint: disable=unused-import

--- a/sqlalchemy_hana/dialect.py
+++ b/sqlalchemy_hana/dialect.py
@@ -31,7 +31,6 @@ from sqlalchemy.engine import Connection, default, reflection
 from sqlalchemy.pool import AsyncAdaptedQueuePool
 from sqlalchemy.schema import CreateColumn
 from sqlalchemy.sql import Select, compiler, functions, sqltypes
-from sqlalchemy.sql.ddl import _DropView as BaseDropView
 from sqlalchemy.sql.elements import (
     BinaryExpression,
     BindParameter,
@@ -42,6 +41,7 @@ from typing_extensions import override
 
 from sqlalchemy_hana import types as hana_types
 from sqlalchemy_hana.elements import CreateView, DropView, Upsert
+import sqlalchemy
 
 if TYPE_CHECKING:
     from typing import ParamSpec, TypeVar
@@ -71,6 +71,12 @@ if TYPE_CHECKING:
 
     RET = TypeVar("RET")
     PARAM = ParamSpec("PARAM")
+
+if sqlalchemy.__version__ < "2.1":
+    from sqlalchemy.sql.ddl import _DropView as BaseDropView
+else:
+    # In SQLAlchemy 2.1, the _DropView class was renamed to DropView.
+    from sqlalchemy.sql.ddl import DropView as BaseDropView
 
 with contextlib.suppress(ImportError):
     # pylint: disable=unused-import


### PR DESCRIPTION
In 2.1, the class was made public, therefore the rename.

Closes #612