### PR TITLE
Remove 2.1 from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
-        sqlalchemy-version: [2.0.*, 2.1.0b2]
+        sqlalchemy-version: [2.0.*]
         async-mode: [non-async]
         include:
         -   python-version: '3.14'


### PR DESCRIPTION
2.1 is not yet released and causes major issues in our CI as all linters are running against 2.0.