### PR TITLE
fix: render NOT (...) for negated boolean predicate on SAP HANA

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,21 @@
 Changelog
 =========
 
+4.6.2
+-----
+
+Fixes
+~~~~~
+
+- Fixed negation of a grouped boolean predicate (e.g. ``~or_(...)``,
+  ``~and_(...)`` or ``not_()`` of a grouping) compiling to
+  ``(<predicate>) = FALSE`` (or ``(<predicate>) = 0`` with
+  ``use_native_boolean=False``), which SAP HANA rejects with error 257
+  ("incorrect syntax near '='"). Such implicitly-boolean expressions now
+  render as ``NOT (...)``. Bare boolean literals and boolean columns keep
+  the explicit ``= TRUE``/``= FALSE`` (``= 1``/``= 0``) comparison that
+  SAP HANA requires.
+
 4.6.1
 -----
 

--- a/sqlalchemy_hana/dialect.py
+++ b/sqlalchemy_hana/dialect.py
@@ -290,10 +290,20 @@ class HANAStatementCompiler(compiler.SQLCompiler):
     # as 1/0; comparing those to the boolean literals TRUE/FALSE raises HANA
     # error 266 (BOOLEAN type is not comparable with INT), so fall back to
     # an INT compare in that mode.
+    # An *implicitly boolean* element (a predicate or grouped boolean
+    # expression such as ``~or_(...)`` or a negated ``LIKE``) must instead be
+    # negated with ``NOT (...)`` / rendered as-is: SAP HANA rejects both
+    # ``(<predicate>) = FALSE`` and ``(<predicate>) = 0`` with error 257
+    # ("incorrect syntax near '='"). This mirrors the branching the base
+    # compiler already performs on ``_is_implicitly_boolean``; the explicit
+    # comparison is only needed for the non-implicitly-boolean case (boolean
+    # literals and boolean columns), which HANA does require.
     @override
     def visit_is_true_unary_operator(
         self, element: UnaryExpression[Any], operator: Any, **kw: Any
     ) -> str:
+        if element.element._is_implicitly_boolean:
+            return self.process(element.element, **kw)
         if not self.dialect.supports_native_boolean:
             return f"{self.process(element.element, **kw)} = 1"
         return f"{self.process(element.element, **kw)} = TRUE"
@@ -302,6 +312,8 @@ class HANAStatementCompiler(compiler.SQLCompiler):
     def visit_is_false_unary_operator(
         self, element: UnaryExpression[Any], operator: Any, **kw: Any
     ) -> str:
+        if element.element._is_implicitly_boolean:
+            return f"NOT {self.process(element.element, **kw)}"
         if not self.dialect.supports_native_boolean:
             return f"{self.process(element.element, **kw)} = 0"
         return f"{self.process(element.element, **kw)} = FALSE"

--- a/test/test_sql_compile.py
+++ b/test/test_sql_compile.py
@@ -2,7 +2,22 @@
 
 from __future__ import annotations
 
-from sqlalchemy import and_, false, func, literal, literal_column, select, true
+from sqlalchemy import (
+    Boolean,
+    Column,
+    Integer,
+    MetaData,
+    Table,
+    and_,
+    false,
+    func,
+    literal,
+    literal_column,
+    not_,
+    or_,
+    select,
+    true,
+)
 from sqlalchemy.sql.expression import column, table
 from sqlalchemy.testing.assertions import AssertsCompiledSQL
 from sqlalchemy.testing.fixtures import TestBase
@@ -83,6 +98,93 @@ class SQLCompileTest(TestBase, AssertsCompiledSQL):
                 and_(false(), literal_column("flag") == literal_column("1"))
             ),
             "SELECT id FROM DUMMY WHERE 0 = 1",
+            dialect=dialect,
+        )
+
+    def test_sql_negated_or_predicate(self) -> None:
+        # Negating a grouped boolean predicate (``~or_(...)``) must render
+        # ``NOT (...)`` and not ``(...) = FALSE`` which SAP HANA rejects with
+        # error 257 ("incorrect syntax near '='").
+        table1 = table("mytable", column("url"))
+        self.assert_compile(
+            select(table1.c.url).where(~or_(table1.c.url.startswith("foo"))),
+            "SELECT mytable.url FROM mytable WHERE NOT (mytable.url LIKE ? || '%')",
+        )
+
+    def test_sql_negated_and_predicate(self) -> None:
+        table1 = table("mytable", column("url"))
+        self.assert_compile(
+            select(table1.c.url).where(~and_(table1.c.url.startswith("foo"))),
+            "SELECT mytable.url FROM mytable WHERE NOT (mytable.url LIKE ? || '%')",
+        )
+
+    def test_sql_negated_grouping_predicate(self) -> None:
+        table1 = table("mytable", column("url"))
+        expected = (
+            "SELECT mytable.url FROM mytable WHERE NOT "
+            "((mytable.url LIKE ? || '%') OR (mytable.url LIKE ? || '%'))"
+        )
+        self.assert_compile(
+            select(table1.c.url).where(
+                not_(
+                    or_(
+                        table1.c.url.startswith("foo"),
+                        table1.c.url.startswith("bar"),
+                    )
+                )
+            ),
+            expected,
+        )
+
+    def test_sql_negated_predicate_non_native(self) -> None:
+        # The same must hold with use_native_boolean=False: ``(<predicate>) = 0``
+        # is also rejected by HANA with error 257, so a negated predicate must
+        # still render as ``NOT (...)``.
+        dialect = HANAHDBCLIDialect(use_native_boolean=False)
+        table1 = table("mytable", column("url"))
+        self.assert_compile(
+            select(table1.c.url).where(~or_(table1.c.url.startswith("foo"))),
+            "SELECT mytable.url FROM mytable WHERE NOT (mytable.url LIKE ? || '%')",
+            dialect=dialect,
+        )
+
+    def test_sql_negated_boolean_column(self) -> None:
+        # A real boolean *column* is not implicitly boolean, so on SAP HANA it
+        # must still be compared explicitly (``NOT flag`` / bare ``flag`` are
+        # rejected by HANA). Native mode uses = TRUE/= FALSE.
+        metadata_table = Table(
+            "mytable",
+            MetaData(),
+            Column("id", Integer, primary_key=True),
+            Column("flag", Boolean),
+        )
+        self.assert_compile(
+            select(metadata_table.c.id).where(~metadata_table.c.flag),
+            "SELECT mytable.id FROM mytable WHERE mytable.flag = FALSE",
+        )
+        self.assert_compile(
+            select(metadata_table.c.id).where(metadata_table.c.flag),
+            "SELECT mytable.id FROM mytable WHERE mytable.flag = TRUE",
+        )
+
+    def test_sql_negated_boolean_column_non_native(self) -> None:
+        # With use_native_boolean=False a boolean column stores as integer, so
+        # it must be compared with = 0/= 1 (not NOT/bare column).
+        dialect = HANAHDBCLIDialect(use_native_boolean=False)
+        metadata_table = Table(
+            "mytable",
+            MetaData(),
+            Column("id", Integer, primary_key=True),
+            Column("flag", Boolean),
+        )
+        self.assert_compile(
+            select(metadata_table.c.id).where(~metadata_table.c.flag),
+            "SELECT mytable.id FROM mytable WHERE mytable.flag = 0",
+            dialect=dialect,
+        )
+        self.assert_compile(
+            select(metadata_table.c.id).where(metadata_table.c.flag),
+            "SELECT mytable.id FROM mytable WHERE mytable.flag = 1",
             dialect=dialect,
         )
 


### PR DESCRIPTION
Fixed negation of a grouped boolean predicate (e.g. ``~or_(...)``, ``~and_(...)`` or ``not_()`` of a grouping) compiling to ``(<predicate>) = FALSE`` (or ``(<predicate>) = 0`` with ``use_native_boolean=False``), which SAP HANA rejects with error ``257 ("incorrect syntax near '='")``. Such implicitly-boolean expressions now render as ``NOT (...)``. Bare boolean literals and boolean columns keep the explicit ``= TRUE``/``= FALSE`` (``= 1``/``= 0``) comparison that SAP HANA requires.